### PR TITLE
Update to npm-package-json-lint v11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "eslint-plugin-unicorn": "^73.0.0",
         "globals": "^17.10.0",
         "jest": "^30.4.2",
-        "npm-package-json-lint": "^10.5.0",
+        "npm-package-json-lint": "^11.0.0",
         "prettier": "^3.9.6"
       },
       "engines": {
@@ -27,7 +27,7 @@
         "npm": ">=10.0.0"
       },
       "peerDependencies": {
-        "npm-package-json-lint": "^10.5.0"
+        "npm-package-json-lint": "^11.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -3333,23 +3333,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -5124,14 +5107,12 @@
       }
     },
     "node_modules/npm-package-json-lint": {
-      "version": "10.5.0",
-      "resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-10.5.0.tgz",
-      "integrity": "sha512-eVz3lgFTs2gc6wrSxlnWIop1TH3WURTFFrX4enUAtn4Zqqc5xtT/ANIwBbMC+Pc+tVig8uay9S660wx93dQiug==",
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/npm-package-json-lint/-/npm-package-json-lint-11.0.0.tgz",
+      "integrity": "sha512-XOFaxHM+TB9tK51Uj609kA1iA87cJe/VNCv/5INLCDbM///KpZpIai+t9LRRyOzvkd62j0JEWKSJeDUlzOSG6Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ajv": "8.20.0",
-        "ajv-errors": "3.0.0",
         "chalk": "4.1.2",
         "cosmiconfig": "10.0.0",
         "debug": "4.4.3",
@@ -5152,40 +5133,6 @@
         "node": ">=22.0.0",
         "npm": ">=10.0.0"
       }
-    },
-    "node_modules/npm-package-json-lint/node_modules/ajv": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
-      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "fast-deep-equal": "^3.1.3",
-        "fast-uri": "^3.0.1",
-        "json-schema-traverse": "^1.0.0",
-        "require-from-string": "^2.0.2"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/epoberezkin"
-      }
-    },
-    "node_modules/npm-package-json-lint/node_modules/ajv-errors": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-3.0.0.tgz",
-      "integrity": "sha512-V3wD15YHfHz6y0KdhYFjyy9vWtEVALT9UrxfN3zqlI6dMioHnJrqOYfyPKol3oqrnCM9uwkcdCwkJ0WUcbLMTQ==",
-      "dev": true,
-      "license": "MIT",
-      "peerDependencies": {
-        "ajv": "^8.0.1"
-      }
-    },
-    "node_modules/npm-package-json-lint/node_modules/json-schema-traverse": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/npm-package-json-lint/node_modules/type-fest": {
       "version": "5.8.0",
@@ -5886,16 +5833,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
       "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
     "eslint-plugin-unicorn": "^73.0.0",
     "globals": "^17.10.0",
     "jest": "^30.4.2",
-    "npm-package-json-lint": "^10.5.0",
+    "npm-package-json-lint": "^11.0.0",
     "prettier": "^3.9.6"
   },
   "peerDependencies": {
-    "npm-package-json-lint": "^10.5.0"
+    "npm-package-json-lint": "^11.0.0"
   },
   "engines": {
     "node": ">=22.0.0",


### PR DESCRIPTION
Bumps the peer and dev dependency to ^11.0.0. All rules used in the
default config are still present in v11, so no rule changes were
needed.